### PR TITLE
ui: exit deck creation

### DIFF
--- a/src/components/Status.tsx
+++ b/src/components/Status.tsx
@@ -364,6 +364,17 @@ function SelectDeck(props: SelectDeckProps) {
     return (
       <div className="relative z-20 w-full">
         <div className="absolute rounded-md bg-neutral-900 p-16" style={{ width: 360 }}>
+          <div className="flex justify-end">
+            <button
+              className=""
+              onClick={() => {
+                set_creating(false);
+                set_card_results([]);
+              }}
+            >
+              ❌
+            </button>
+          </div>
           <div className="flex w-full flex-col items-start">
             <div className="mb-4 flex flex-row flex-wrap items-center justify-center">
               {create_deck.map((id) => {


### PR DESCRIPTION
Adds the ability for users to exit the deck creation pop up. This will reset the state of results, but not the state of the cards selected for the deck.

<img width="361" alt="Screen Shot 2022-11-13 at 2 08 07 PM" src="https://user-images.githubusercontent.com/69382434/201546958-0c64937b-34c5-45a5-89a9-1d45c2a98118.png">
